### PR TITLE
This patch does these cosmetic changes to the UI

### DIFF
--- a/data/ui/plugin-row.ui
+++ b/data/ui/plugin-row.ui
@@ -74,14 +74,14 @@
             <signal name="notify::active" handler="loaded_switch_changed" object="GtdPluginDialogRow" swapped="yes" />
           </object>
           <packing>
-            <property name="left_attach">3</property>
+            <property name="left_attach">4</property>
             <property name="top_attach">0</property>
             <property name="height">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkButton" id="preferences_button">
-            <property name="visible">True</property>
+            <property name="visible">False</property>
             <property name="can_focus">True</property>
             <property name="sensitive">False</property>
             <property name="halign">center</property>
@@ -100,7 +100,7 @@
             </child>
           </object>
           <packing>
-            <property name="left_attach">4</property>
+            <property name="left_attach">3</property>
             <property name="top_attach">0</property>
             <property name="height">2</property>
           </packing>

--- a/src/gtd-plugin-dialog-row.c
+++ b/src/gtd-plugin-dialog-row.c
@@ -280,7 +280,7 @@ gtd_plugin_dialog_row_set_plugin (GtdPluginDialogRow *row,
       show_preferences = activatable != NULL &&
                          gtd_activatable_get_preferences_panel (activatable) != NULL;
 
-      gtk_widget_set_sensitive (row->preferences_button, show_preferences);
+      gtk_widget_set_visible (row->preferences_button, show_preferences);
 
       /* Setup the switch and make sure we don't fire notify::active */
       g_signal_handlers_block_by_func (row->loaded_switch,


### PR DESCRIPTION
1) The preference button for plugins only shows up when the plugin has a preference window + the plugin is active.
2) The position of preference button and plugin activate button has been switched to allow for a more uniform look.