### PR TITLE
Dependencies needed to build on Fedora 26

### DIFF
--- a/README
+++ b/README
@@ -3,3 +3,8 @@ GNOME To Do
 GNOME To Do is a small application to manage your personal tasks. It
 uses GNOME technologies, and so it has complete integration with the
 GNOME desktop environment.
+
+Dependencies
+
+Fedora 26
+meson glib* evolution-data-server-devel rest-devel libpeas-devel gnome-online-accounts-devel gtk3-devel


### PR DESCRIPTION
After spending a chunk of time tracking down what packages provided the native dependencies, I figured I could save the next fellow some time with the initial build process if the dependencies were easily available.

installing glib* is probably not the cleanest, but glib2-devel didn't yield the desired result.